### PR TITLE
Bug Fix: SSL get headers image verification

### DIFF
--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -103,6 +103,13 @@ class OpenGraph
         }
 
         try {
+            stream_context_set_default( [
+			    'ssl' => [
+			        'verify_peer' => false,
+			        'verify_peer_name' => false,
+			    ],
+			]);
+            
             $headers = get_headers($url);
 
             return stripos($headers[0], '200 OK') ? true : false;


### PR DESCRIPTION
Fixes a bug related to Issue #83 on main repository where after verifying the problem it was determined that SSL marked as Wildcard ( * ) can cause problems with "get_headers" function in php.

It was assumed previously that "FILTER_VALIDATE_URL" was being too strict, but later determined that SSL verification was failing.